### PR TITLE
Typography – Use prime and double prime symbols

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A simple and flexible tool to format decimal lat/lon coordinates into degrees/minutes/seconds formats (like DMS), using a [moment.js](http://momentjs.com/)-like API.
 
-For geo hipsters that think that **48° 54´ 16.016" S 71° 0´ 56.250" W** looks way more awesome than **-48.9044488,-71.015625**.
+For geo hipsters that think that **48° 54′ 16.016″ S 71° 0′ 56.250″ W** looks way more awesome than **-48.9044488,-71.015625**.
 
 ## install: node/browserify
 
@@ -17,7 +17,7 @@ npm install formatcoords
 ```
 var formatcoords = require('formatcoords');
 formatcoords(40.76,-73.984).format();
-//40° 45' 36.000" N 73° 59' 2.400" W
+//40° 45′ 36.000″ N 73° 59′ 2.400″ W
 ```
 
 #### parsing
@@ -43,7 +43,7 @@ coords.format(format, {options})
 Default output format is DMS (degrees minutes seconds), with a space to separate lat and lon, and 5 decimal places :
 ```
 coords.format()
-//27° 43´ 31.796" N 18° 1´ 27.484" W
+//27° 43′ 31.796″ N 18° 1′ 27.484″ W
 ```
 
 
@@ -51,8 +51,8 @@ coords.format()
 
 |                       | Token   | Output |
 |----------------------:|:--------|--------|
-|degrees minutes seconds (DMS)|FFf        |27° 43´ 31.796" N 18° 1´ 27.484" W        |
-|degrees decimal minutes|Ff       |27° 43.529933333333´ N -18° 1.4580666666667´ W       |
+|degrees minutes seconds (DMS)|FFf        |27° 43′ 31.796″ N 18° 1′ 27.484″ W        |
+|degrees decimal minutes|Ff       |27° 43.529933333333′ N -18° 1.4580666666667′ W       |
 |decimal degrees        |f        |27.725499° N 18.024301° W        |
 
 *Custom formats:*
@@ -66,11 +66,11 @@ The following values are available for both latitudes and longitudes:
 |decimal degrees                |d        |27.725499        |
 |decimal degrees with unit      |dd       |27.725499°        |
 |minutes                        |M        |7        |
-|minutes with unit              |MM       |7´        |
+|minutes with unit              |MM       |7′        |
 |decimal minutes                |m        |7.63346        |
-|decimal minutes with unit      |mm       |7.63346´        |
+|decimal minutes with unit      |mm       |7.63346′        |
 |decimal seconds                |s        |31.796        |
-|decimal seconds with unit      |ss       |31.796"        |
+|decimal seconds with unit      |ss       |31.796″        |
 |direction                      |X        |[N,S], [E,W]        |
 |minus sign (west of Greenwich and south of equator)|-        |[-]        |
 
@@ -91,7 +91,7 @@ coord.format('-D M s');
 
 ```
 coord.format('DD MM ss X', {latLonSeparator: ', ',  decimalPlaces: 0);
-//35° 43´ 49" S, 86° 1´ 55" E
+//35° 43′ 49″ S, 86° 1′ 55″ E
 ```
 
 

--- a/index.js
+++ b/index.js
@@ -63,8 +63,8 @@ var shortFormats = {
 
 var units = {
 	degrees: '°',
-	minutes: '´',
-	seconds: '"',
+	minutes: '′',
+	seconds: '″',
 };
 
 Coords.prototype.format = function(format, options) {

--- a/test/test.js
+++ b/test/test.js
@@ -6,8 +6,8 @@ var formatcoords = require('../index');
 var expect = require("chai").expect;
 
 var coords = {
-	floats: formatcoords(-35.282000, 149.128684), 
-	floatslonlat: formatcoords(149.128684, -35.282000, true), 
+	floats: formatcoords(-35.282000, 149.128684),
+	floatslonlat: formatcoords(149.128684, -35.282000, true),
 	array: formatcoords([-35.282000, 149.128684]),
 	arraylonlat: formatcoords([149.128684, -35.282000], true),
 	string: formatcoords('-35.282000, 149.128684'),
@@ -57,11 +57,11 @@ describe('formatcoords()', function() {
 
 });
 
-var coord = coords.floats; 
+var coord = coords.floats;
 
 describe('Coords', function () {
 	describe('#compute()', function() {
-		
+
 		it('should have north value set to false', function () {
 			expect(coord.north).to.be.false;
 		} );
@@ -96,11 +96,11 @@ describe('Coords', function () {
 	});
 
 	describe('#format()', function() {
-		it('should render to 35° 16´ 55.20000" S 149° 7´ 43.26240" E by default (DMS)', function() {
-			expect(coord.format()).to.equal('35° 16´ 55.20000" S 149° 7´ 43.26240" E');
+		it('should render to 35° 16′ 55.20000″ S 149° 7′ 43.26240″ E by default (DMS)', function() {
+			expect(coord.format()).to.equal('35° 16′ 55.20000″ S 149° 7′ 43.26240″ E');
 		});
-		it('should render to 35° 16.920´ S 149° 7.721´ E when using "Ff" (DM)', function() {
-			expect(coord.format('Ff')).to.equal('35° 16.92000´ S 149° 7.72104´ E');
+		it('should render to 35° 16.920′ S 149° 7.721′ E when using "Ff" (DM)', function() {
+			expect(coord.format('Ff')).to.equal('35° 16.92000′ S 149° 7.72104′ E');
 		});
 		it('should render to 35.282° S 149.12868° E when using "f" (decimal degrees)', function() {
 			expect(coord.format('f')).to.equal('35.28200° S 149.12868° E');
@@ -111,11 +111,11 @@ describe('Coords', function () {
 		it ('should render to -35 16 55.20000, 149 7 43.26240 when using custom format "D M s" (GPS format) and custom separator', function() {
 			expect(coord.format('-D M s', {latLonSeparator: ', '})).to.equal('-35 16 55.20000, 149 7 43.26240');
 		});
-		it ('should render to 35° 16´ 55" S, 149° 7´ 43" E when using custom format "DD MM ss X" and complete options object', function() {
-			expect(coord.format('DD MM ss X',  {latLonSeparator: ' - ', decimalPlaces: 0})).to.equal('35° 16´ 55" S - 149° 7´ 43" E');
+		it ('should render to 35° 16′ 55″ S, 149° 7′ 43″ E when using custom format "DD MM ss X" and complete options object', function() {
+			expect(coord.format('DD MM ss X',  {latLonSeparator: ' - ', decimalPlaces: 0})).to.equal('35° 16′ 55″ S - 149° 7′ 43″ E');
 		});
-		it ('should render to 35° 16´ 55" S, 149° 7´ 43" E when only passing options object and forgetting format', function() {
-			expect(coord.format({decimalPlaces: 0})).to.equal('35° 16´ 55" S 149° 7´ 43" E');
+		it ('should render to 35° 16′ 55″ S, 149° 7′ 43″ E when only passing options object and forgetting format', function() {
+			expect(coord.format({decimalPlaces: 0})).to.equal('35° 16′ 55″ S 149° 7′ 43″ E');
 		});
 	});
 });


### PR DESCRIPTION
Sorry, this is just some typographical nitpicking. 🤓 

Coordinates should be displayed with the correct symbols (i.e. prime & double prime) instead of acute accents `´` and double quotation marks `"`.

_c.f. https://en.wikipedia.org/wiki/Prime_(symbol) and https://en.wikipedia.org/wiki/Geographic_coordinate_conversion_