### PR TITLE
Bugfix: accept {lat,lng} with a coordinate value equal 0

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ Coords.prototype.init = function() {
 	if (!arguments.length) {
 		throw new Error('no arguments');
 	}
-	else if (arguments[0].lat && arguments[0].lng) {
+	else if (typeof arguments[0] === 'object' && 'lat' in arguments[0] && 'lng' in arguments[0]) {
 		this.lat = arguments[0].lat;
 		this.lon = arguments[0].lng;
 	}

--- a/test/test.js
+++ b/test/test.js
@@ -57,6 +57,18 @@ describe('formatcoords()', function() {
 
 });
 
+describe('formatcoords() special cases', function() {
+	it('{lat:-35,lng:0}', function () {
+		let coord = formatcoords({lat:-35, lng: 0})
+		expect(coord.lat).to.exist;
+		expect(coord.lon).to.exist;
+		expect(coord.lat).to.be.a('number');
+		expect(coord.lon).to.be.a('number');
+		expect(coord.lat).to.equal(-35);
+		expect(coord.lon).to.equal(0);
+	});
+});
+
 var coord = coords.floats;
 
 describe('Coords', function () {


### PR DESCRIPTION
I found a bug! If you provide coordinates as object and either lat or lng are 0, I will get 'NaN' as result. This pull request fixes this behavior and also provides a test.