### PR TITLE
Added "S" formating for seconds integer value to avoid rounding issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ The following values are available for both latitudes and longitudes:
 |minutes with unit              |MM       |7′        |
 |decimal minutes                |m        |7.63346        |
 |decimal minutes with unit      |mm       |7.63346′        |
+|seconds                        |S        |31        |
+|seconds with unit              |SS       |31″        |
 |decimal seconds                |s        |31.796        |
 |decimal seconds with unit      |ss       |31.796″        |
 |direction                      |X        |[N,S], [E,W]        |

--- a/index.js
+++ b/index.js
@@ -51,6 +51,7 @@ Coords.prototype.compute = function() {
 		values.minutes = values.secondsTotal / 60; 
 		values.minutesInt = Math.floor(values.minutes);
 		values.seconds = values.secondsTotal - (values.minutesInt * 60);
+		values.secondsInt = Math.floor(values.seconds);
 		return values;
 	}
 };
@@ -115,6 +116,8 @@ Coords.prototype.format = function(format, options) {
 		formatted = formatted.replace(/m/g, values.minutes.toFixed(options.decimalPlaces));
 		formatted = formatted.replace(/ss/g, values.seconds.toFixed(options.decimalPlaces)+units.seconds);
 		formatted = formatted.replace(/s/g, values.seconds.toFixed(options.decimalPlaces));
+		formatted = formatted.replace(/SS/g, values.secondsInt.toFixed(options.decimalPlaces)+units.seconds);
+		formatted = formatted.replace(/S/g, values.secondsInt.toFixed(options.decimalPlaces));
 		
 		formatted = formatted.replace(/-/g, (values.initValue<0) ? '-' : '');
 		


### PR DESCRIPTION
There is a rounding issue for seconds already reported [here](https://github.com/nerik/formatcoords/issues/5)
To avoid the issue I would like to add "SS" and "S" formatting which is using seconds integer value.